### PR TITLE
optimisation of uri_escape

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -35,6 +35,8 @@ static char escapes[256] =
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
 };
 
+static char hex_chars[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
 SV *encode_uri_component(SV *sstr){
     SV *str, *result;
     int slen, dlen;
@@ -52,8 +54,9 @@ SV *encode_uri_component(SV *sstr){
 
     for (i = 0; i < slen; i++){
 	if (escapes[ src[i] ]){
-	    sprintf((char *)(dst + dlen), "%%%02X", src[i]);
-	    dlen += 3;
+	    dst[dlen++] = '%';
+	    dst[dlen++] = hex_chars[src[i]>>4];
+	    dst[dlen++] = hex_chars[src[i]%16];
 	}
 	else{
 	    dst[dlen++] = src[i];


### PR DESCRIPTION
A little optimisation of uri_escape - we can convert uint8 to hex representation without sprintf overhead.
For performance test I used this script: 
time perl -I lib/ -I ./blib/arch -e 'use URI::Escape::XS qw/uri_escape/; my $data = join "", map {chr($_)} 0..255; for (1..1e6) {uri_escape($data)}'

old time:
real    0m34.706s
user    0m34.676s
sys 0m0.024s

new time:
real    0m2.167s
user    0m2.159s
sys 0m0.006s
